### PR TITLE
Several improvements to make this more reusable outside of founding usecase

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,4 +2,7 @@
     "editor.formatOnSave": true,
     "editor.cursorBlinking": "smooth",
     "editor.cursorSmoothCaretAnimation": "on",
+    "rust-analyzer.cargo.features": [
+        "bevy"
+    ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "editor.formatOnSave": true,
+    "editor.cursorBlinking": "smooth",
+    "editor.cursorSmoothCaretAnimation": "on",
+}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Could be used with the Bevy game engine for fast processing of voxel data or as 
 
 To enable bevy integrations:
 
-```
+```toml
 [dependencies]
 oktree = { version = "0.2.0", features = ["bevy"] }
 ```

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ Compensation for the inconvenience is perfomance.
 
 Octree dimensions: `4096x4096x4096`
 
-| Operation           | Quantity                         | Time  |
-| ------------------- | -------------------------------- | ----- |
-| insertion           | 65536 cells                      | 25 ms |
-| removing            | 65536 cells                      | 12 ms |
-| find                | 65536 searches in 65536 cells    | 13 ms |
-| ray intersection    | 4096 rays against 65536 cells    | 35 ms |
-| sphere intersection | 4096 spheres against 65536 cells | 8 ms  |
-| box intersection    | 4096 boxes against 65536 cells   | 6 ms  |
+| Operation           | Quantity                         | Time    |
+| ------------------- | -------------------------------- | ------- |
+| insertion           | 65536 cells                      | 7.30 ms |
+| removing            | 65536 cells                      | 3.63 ms |
+| find                | 65536 searches in 65536 cells    | 5.63 ms |
+| ray intersection    | 4096 rays against 65536 cells    | 19.1 ms |
+| sphere intersection | 4096 spheres against 65536 cells | 4.71 ms |
+| box intersection    | 4096 boxes against 65536 cells   | 4.47 ms |
 
 Run benchmark:
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -136,7 +136,7 @@ fn octree_insert_using_clear(
     }
 }
 
-fn octree_remove(tree: &mut Octree<usize, DummyCell<usize>>, points: &[DummyCell<usize>]) {
+fn octree_remove(tree: &mut Octree<usize, DummyCell<usize>>) {
     tree.restore_garbage();
     for element in 0..tree.len() {
         let _ = tree.remove(element.into());
@@ -181,9 +181,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     let mut tree = octree_insert(&points);
-    group.bench_function("octree remove", |b| {
-        b.iter(|| octree_remove(&mut tree, &points))
-    });
+    group.bench_function("octree remove", |b| b.iter(|| octree_remove(&mut tree)));
 
     let tree = octree_insert(&points);
     group.bench_function("octree find", |b| b.iter(|| octree_find(&tree, &points)));

--- a/evidence/run-19-11-2024.txt
+++ b/evidence/run-19-11-2024.txt
@@ -1,0 +1,57 @@
+warning: `oktree` (bench "benchmark") generated 1 warning
+    Finished `bench` profile [optimized] target(s) in 0.23s
+     Running unittests src\lib.rs (target\release\deps\oktree-d18a0bf0eb4a257c.exe)
+
+running 13 tests
+test bevy_integration::tests::intersect_volume ... ignored
+test bevy_integration::tests::intersects_volume ... ignored
+test bevy_integration::tests::test_ray_intersection ... ignored
+test bounding::tests::test_aabb_constructor ... ignored
+test bounding::tests::test_aabb_contains ... ignored
+test bounding::tests::test_ispower2 ... ignored
+test tests::test_65536 ... ignored
+test tests::test_constructors ... ignored
+test tests::test_insert ... ignored
+test tests::test_insert_remove ... ignored
+test tests::test_iterator ... ignored
+test tests::test_remove ... ignored
+test tests::test_to_vec ... ignored
+
+test result: ok. 0 passed; 0 failed; 13 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running benches\benchmark.rs (target\release\deps\benchmark-dd3a8455683eaeee.exe)
+Gnuplot not found, using plotters backend
+main/octree insert      time:   [7.2431 ms 7.2980 ms 7.3557 ms]
+                        change: [-9.9618% -7.5500% -5.2564%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 7 outliers among 100 measurements (7.00%)
+  6 (6.00%) high mild
+  1 (1.00%) high severe
+Benchmarking main/octree remove: Warming up for 3.0000 s
+Warning: Unable to complete 100 samples in 10.0s. You may wish to increase target time to 17.7s, enable flat sampling, or reduce sample count to 50.
+main/octree remove      time:   [3.5506 ms 3.6261 ms 3.7001 ms]
+                        change: [-51.150% -46.421% -40.788%] (p = 0.00 < 0.05)
+                        Performance has improved.
+main/octree find        time:   [5.5770 ms 5.6335 ms 5.6921 ms]
+                        change: [-33.700% -29.984% -26.025%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+main/octree ray cast    time:   [19.001 ms 19.110 ms 19.221 ms]
+                        change: [-24.917% -21.430% -17.776%] (p = 0.00 < 0.05)
+                        Performance has improved.
+main/octree sphere intersect
+                        time:   [4.6761 ms 4.7059 ms 4.7348 ms]
+                        change: [+1.5711% +2.5875% +3.5691%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) low mild
+main/octree aabb intersect
+                        time:   [4.3103 ms 4.4650 ms 4.6386 ms]
+                        change: [-0.2312% +3.4190% +7.3663%] (p = 0.08 > 0.05)
+                        No change in performance detected.
+Found 12 outliers among 100 measurements (12.00%)
+  1 (1.00%) high mild
+  11 (11.00%) high severe
+
+PS C:\Users\johna\prog\oktree>

--- a/examples/bevy_tree.rs
+++ b/examples/bevy_tree.rs
@@ -42,7 +42,7 @@ fn setup(mut commands: Commands) {
 }
 
 fn draw_nodes(mut gizmos: Gizmos, tree: Res<Tree>) {
-    for node in tree.0.nodes.iter() {
+    for node in tree.0.iter_nodes() {
         let scale = node.aabb.size() as f32;
         let transform =
             Transform::from_translation(node.aabb.center().into()).with_scale(Vec3::splat(scale));
@@ -56,7 +56,7 @@ fn draw_nodes(mut gizmos: Gizmos, tree: Res<Tree>) {
 }
 
 fn draw_elements(mut gizmos: Gizmos, tree: Res<Tree>) {
-    for element in tree.0.elements.iter() {
+    for element in tree.0.iter() {
         gizmos.sphere(element.position.into(), Quat::IDENTITY, 1.0, RED);
     }
 }

--- a/src/bevy_integration.rs
+++ b/src/bevy_integration.rs
@@ -261,8 +261,8 @@ where
     /// let c1_id = tree.insert(c1).unwrap();
     ///
     /// let mut elements = Vec::new();
-    /// tree.intersect_with_for_each(|_| true, |e| elements.push(e) );
-    /// assert_eq!(elements, vec![c1_id]);
+    /// tree.intersect_with_for_each(|_| true, |e| elements.push(e.clone()) );
+    /// assert_eq!(elements, vec![c1]);
     /// ```
     pub fn intersect_with_for_each<F, F2>(&self, what: F, mut actor: F2)
     where

--- a/src/bevy_integration.rs
+++ b/src/bevy_integration.rs
@@ -115,7 +115,7 @@ where
         }
     }
 
-    /// Intersect [`Octree`] with a custom .
+    /// Intersect [`Octree`] with a custom intersection closure.
     ///
     /// Returns the [`vector`](Vec) of [`elements`](ElementId),
     /// intersected by volume.
@@ -127,12 +127,7 @@ where
     /// let c1_id = tree.insert(c1).unwrap();
     ///
     /// // Bounding box intersection
-    /// let aabb = Aabb3d::new(Vec3::new(0.0, 0.0, 0.0), Vec3::splat(5.0));
-    /// assert_eq!(tree.intersect(&aabb), vec![c1_id]);
-    ///
-    /// // Bounding sphere intersection
-    /// let sphere = BoundingSphere::new(Vec3::new(0.0, 0.0, 0.0), 6.0);
-    /// assert_eq!(tree.intersect(&sphere), vec![c1_id]);
+    /// assert_eq!(tree.intersect_with(|_| true), vec![c1_id]);
     /// ```
     pub fn intersect_with<F>(&self, what: F) -> Vec<ElementId>
     where

--- a/src/bevy_integration.rs
+++ b/src/bevy_integration.rs
@@ -166,11 +166,11 @@ where
     /// let mut elements = Vec::new();
     /// assert_eq!(tree.extend_intersect_with(|_| true, &mut elements), vec![c1_id]);
     /// ```
-    pub fn extend_intersect_with<F>(&self, what: &F, elements: &mut Vec<ElementId>)
+    pub fn extend_intersect_with<F>(&self, what: F, elements: &mut Vec<ElementId>)
     where
         F: Fn(&Aabb<U>) -> bool,
     {
-        self.rintersect_with(self.root, what, elements);
+        self.rintersect_with(self.root, &what, elements);
     }
 
     fn rintersect_with<F>(&self, node: NodeId, what: &F, elements: &mut Vec<ElementId>)

--- a/src/bevy_integration.rs
+++ b/src/bevy_integration.rs
@@ -5,32 +5,56 @@
 //! ### Intersections:
 //! - [`ray`](RayCast3d) [intersection](Octree::ray_cast)
 //!
-//! ```ignore
-//! let ray = RayCast3d::new(Vec3A::new(7.0, 5.9, 1.01), Dir3A::NEG_X, 10.0);
+//! ```rust
+//! use oktree::prelude::*;
+//! use bevy::prelude::*;
+//! use bevy::math::{bounding::RayCast3d, Vec3A};
+//!
+//! let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16).unwrap());
+//! tree.insert(TUVec3u8::new(1, 1, 1));
+//!
+//! let ray = RayCast3d::new(Vec3A::new(5.0, 1.5, 1.5), Dir3A::NEG_X, 10.0);
 //! assert_eq!(
 //!   tree.ray_cast(&ray),
 //!   HitResult {
-//!     element: Some(1.into()),
-//!     distance: 5.0
+//!     element: Some(0.into()),
+//!     distance: 3.0
 //!   }
 //! );
 //! ```
 //!
 //! - [`Sphere`](BoundingSphere) [intersection](Octree::intersect)
 //!
-//! ```ignore
+//! ```rust
+//! use oktree::prelude::*;
+//! use bevy::prelude::*;
+//! use bevy::math::bounding::BoundingSphere;
+//!
+//! let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16).unwrap());
+//! tree.insert(TUVec3u8::new(1, 1, 1));
+//!
 //! let sphere = BoundingSphere::new(Vec3::new(0.0, 0.0, 0.0), 10.0);
 //! assert_eq!(
 //!   tree.intersect(&sphere),
-//!   vec![ElementId(0), ElementId(1), ElementId(2)]
+//!   vec![ElementId(0)]
 //! );
 //! ```
 //!
 //! - [`Aabb`](Aabb3d) [intersection](Octree::intersect)
 //!
-//! ```ignore
+//! ```rust
+//! use oktree::prelude::*;
+//! use bevy::prelude::*;
+//! use bevy::math::{bounding::Aabb3d, Vec3};
+//!
+//!  let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16).unwrap());
+//! tree.insert(TUVec3u8::new(1, 1, 1));
+//! tree.insert(TUVec3u8::new(2, 2, 2));
+//!
 //! let aabb = Aabb3d::new(Vec3::new(0.0, 0.0, 0.0), Vec3::splat(5.0));
-//! assert_eq!(tree.intersect(&aabb), vec![ElementId(0), ElementId(1)]);
+//! let mut test = tree.intersect(&aabb);
+//! test.sort();
+//! assert_eq!(test, vec![ElementId(0), ElementId(1)]);
 //! ```
 
 use bevy::math::{
@@ -57,10 +81,14 @@ where
     /// Returns a [`HitResult`] with [`ElementId`] and the doistance to
     /// the intersection if any.
     ///
-    /// ```ignore
-    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
+    /// ```rust
+    /// use oktree::prelude::*;
+    /// use bevy::prelude::*;
+    /// use bevy::math::{bounding::RayCast3d, Vec3A};
     ///
-    /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
+    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16).unwrap());
+    ///
+    /// let c1 = TUVec3u8::new(1u8, 1, 1);
     /// let c1_id = tree.insert(c1).unwrap();
     ///
     /// let ray = RayCast3d::new(Vec3A::new(5.0, 1.5, 1.5), Dir3A::NEG_X, 10.0);
@@ -69,7 +97,7 @@ where
     ///     tree.ray_cast(&ray),
     ///     HitResult {
     ///         element: Some(c1_id),
-    ///         distance: 4.0
+    ///         distance: 3.0
     ///     }
     /// )
     /// ```
@@ -132,10 +160,13 @@ where
     /// Returns the [`vector`](Vec) of [`elements`](ElementId),
     /// intersected by volume.
     ///
-    /// ```ignore
-    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
+    /// ```rust
+    /// use oktree::prelude::*;
+    /// use bevy::prelude::*;
     ///
-    /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
+    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16).unwrap());
+    ///
+    /// let c1 = TUVec3u8::new(1u8, 1, 1);
     /// let c1_id = tree.insert(c1).unwrap();
     ///
     /// // Bounding box intersection
@@ -156,15 +187,19 @@ where
     /// Returns the [`vector`](Vec) of [`elements`](ElementId),
     /// intersected by volume.
     ///
-    /// ```ignore
-    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
+    /// ```rust
+    /// use oktree::prelude::*;
+    /// use bevy::prelude::*;
     ///
-    /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
+    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16).unwrap());
+    ///
+    /// let c1 = TUVec3u8::new(1u8, 1, 1);
     /// let c1_id = tree.insert(c1).unwrap();
     ///
     /// // Bounding box intersection
     /// let mut elements = Vec::new();
-    /// assert_eq!(tree.extend_intersect_with(|_| true, &mut elements), vec![c1_id]);
+    /// tree.extend_intersect_with(|_| true, &mut elements);
+    /// assert_eq!(elements, vec![c1_id]);
     /// ```
     pub fn extend_intersect_with<F>(&self, what: F, elements: &mut Vec<ElementId>)
     where
@@ -177,7 +212,7 @@ where
     where
         F: Fn(&Aabb<U>) -> bool,
     {
-        // We use a heapless stack to loop through the nodes until we complete the cast however
+        // We use a heapless stack to loop through the nodes until we complete the intersect however
         // if the stack becomes full then then we fallbackon recursive calls.
         let mut stack = HVec::<_, 32>::new();
         stack.push(node).unwrap();
@@ -212,15 +247,84 @@ where
         }
     }
 
+    /// Intersect [`Octree`] with a custom intersection closure reusing a
+    /// supplied [`vector`](Vec) rather than allocating a new one. Each element
+    /// that intersects with the volume is passed to the supplied closure.
+    ///
+    /// ```rust
+    /// use oktree::prelude::*;
+    /// use bevy::prelude::*;
+    ///
+    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16).unwrap());
+    ///
+    /// let c1 = TUVec3u8::new(1u8, 1, 1);
+    /// let c1_id = tree.insert(c1).unwrap();
+    ///
+    /// let mut elements = Vec::new();
+    /// tree.intersect_with_for_each(|_| true, |e| elements.push(e) );
+    /// assert_eq!(elements, vec![c1_id]);
+    /// ```
+    pub fn intersect_with_for_each<F, F2>(&self, what: F, mut actor: F2)
+    where
+        F: Fn(&Aabb<U>) -> bool,
+        F2: FnMut(ElementId),
+    {
+        self.rintersect_with_for_each(self.root, &what, &mut actor);
+    }
+
+    fn rintersect_with_for_each<F, F2>(&self, node: NodeId, what: &F, actor: &mut F2)
+    where
+        F: Fn(&Aabb<U>) -> bool,
+        F2: FnMut(ElementId),
+    {
+        // We use a heapless stack to loop through the nodes until we complete the intersect however
+        // if the stack becomes full then then we fallbackon recursive calls.
+        let mut stack = HVec::<_, 32>::new();
+        stack.push(node).unwrap();
+        while let Some(node) = stack.pop() {
+            let n = self.nodes[node];
+            match n.ntype {
+                NodeType::Empty => (),
+
+                NodeType::Leaf(e) => {
+                    let aabb = self.elements[e].position().unit_aabb();
+                    if what(&aabb) {
+                        actor(e);
+                    };
+                }
+
+                NodeType::Branch(Branch { children, .. }) => {
+                    if what(&n.aabb) {
+                        let mut iter = children.into_iter();
+                        while let Some(child) = iter.next() {
+                            // If we can't push to the stack (to be processed on the next loop
+                            // iteration) then we fallback to recursive calls.
+                            if stack.push(child).is_err() {
+                                self.rintersect_with_for_each(child, what, actor);
+                                while let Some(child) = iter.next() {
+                                    self.rintersect_with_for_each(child, what, actor);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     /// Intersect [`Octree`] with [`Aabb3d`] or [`BoundingSphere`].
     ///
     /// Returns the [`vector`](Vec) of [`elements`](ElementId),
     /// intersected by volume.
     ///
-    /// ```ignore
-    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
+    /// ```rust
+    /// use oktree::prelude::*;
+    /// use bevy::prelude::*;
+    /// use bevy::math::{bounding::{BoundingSphere, Aabb3d}, Vec3};
     ///
-    /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
+    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16).unwrap());
+    ///
+    /// let c1 = TUVec3u8::new(1u8, 1, 1);
     /// let c1_id = tree.insert(c1).unwrap();
     ///
     /// // Bounding box intersection
@@ -536,27 +640,33 @@ mod tests {
         assert_eq!(tree.insert(c3), Ok(ElementId(2)));
 
         let box1 = Aabb3d::new(Vec3::new(0.0, 0.0, 0.0), Vec3::splat(10.0));
-        assert_eq!(
-            tree.intersect(&box1),
-            vec![ElementId(0), ElementId(1), ElementId(2)]
-        );
+        let mut test = tree.intersect(&box1);
+        test.sort();
+        assert_eq!(test, vec![ElementId(0), ElementId(1), ElementId(2)]);
 
         let box2 = Aabb3d::new(Vec3::new(0.0, 0.0, 0.0), Vec3::splat(5.0));
-        assert_eq!(tree.intersect(&box2), vec![ElementId(0), ElementId(1)]);
+        let mut test = tree.intersect(&box2);
+        test.sort();
+        assert_eq!(test, vec![ElementId(0), ElementId(1)]);
 
         let box3 = Aabb3d::new(Vec3::new(10.0, 0.0, 10.0), Vec3::splat(5.0));
-        assert_eq!(tree.intersect(&box3), vec![]);
+        let mut test = tree.intersect(&box3);
+        test.sort();
+        assert_eq!(test, vec![]);
 
         let sphere1 = BoundingSphere::new(Vec3::new(0.0, 0.0, 0.0), 10.0);
-        assert_eq!(
-            tree.intersect(&sphere1),
-            vec![ElementId(0), ElementId(1), ElementId(2)]
-        );
+        let mut test = tree.intersect(&sphere1);
+        test.sort();
+        assert_eq!(test, vec![ElementId(0), ElementId(1), ElementId(2)]);
 
         let sphere2 = BoundingSphere::new(Vec3::new(0.0, 0.0, 0.0), 6.0);
-        assert_eq!(tree.intersect(&sphere2), vec![ElementId(0), ElementId(1)]);
+        let mut test = tree.intersect(&sphere2);
+        test.sort();
+        assert_eq!(test, vec![ElementId(0), ElementId(1)]);
 
         let sphere3 = BoundingSphere::new(Vec3::new(10.0, 0.0, 10.0), 5.0);
-        assert_eq!(tree.intersect(&sphere3), vec![]);
+        let mut test = tree.intersect(&sphere3);
+        test.sort();
+        assert_eq!(test, vec![]);
     }
 }

--- a/src/bevy_integration.rs
+++ b/src/bevy_integration.rs
@@ -267,7 +267,7 @@ where
     pub fn intersect_with_for_each<F, F2>(&self, what: F, mut actor: F2)
     where
         F: Fn(&Aabb<U>) -> bool,
-        F2: FnMut(ElementId),
+        F2: FnMut(&T),
     {
         self.rintersect_with_for_each(self.root, &what, &mut actor);
     }
@@ -275,7 +275,7 @@ where
     fn rintersect_with_for_each<F, F2>(&self, node: NodeId, what: &F, actor: &mut F2)
     where
         F: Fn(&Aabb<U>) -> bool,
-        F2: FnMut(ElementId),
+        F2: FnMut(&T),
     {
         // We use a heapless stack to loop through the nodes until we complete the intersect however
         // if the stack becomes full then then we fallbackon recursive calls.
@@ -287,7 +287,8 @@ where
                 NodeType::Empty => (),
 
                 NodeType::Leaf(e) => {
-                    let aabb = self.elements[e].position().unit_aabb();
+                    let e = &self.elements[e];
+                    let aabb = e.position().unit_aabb();
                     if what(&aabb) {
                         actor(e);
                     };

--- a/src/bevy_integration.rs
+++ b/src/bevy_integration.rs
@@ -56,7 +56,7 @@ where
     /// Returns a [`HitResult`] with [`ElementId`] and the doistance to
     /// the intersection if any.
     ///
-    /// ```no_run
+    /// ```ignore
     /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
     ///
     /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
@@ -120,7 +120,7 @@ where
     /// Returns the [`vector`](Vec) of [`elements`](ElementId),
     /// intersected by volume.
     ///
-    /// ```no_run
+    /// ```ignore
     /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
     ///
     /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));

--- a/src/bevy_integration.rs
+++ b/src/bevy_integration.rs
@@ -136,7 +136,7 @@ where
     /// ```
     pub fn intersect_with<F>(&self, what: F) -> Vec<ElementId>
     where
-        F: Fn(&Aabb3d) -> bool,
+        F: Fn(&Aabb<U>) -> bool,
     {
         let mut elements = Vec::with_capacity(10);
         self.rintersect_with(self.root, &what, &mut elements);
@@ -145,23 +145,21 @@ where
 
     fn rintersect_with<F>(&self, node: NodeId, what: &F, elements: &mut Vec<ElementId>)
     where
-        F: Fn(&Aabb3d) -> bool,
+        F: Fn(&Aabb<U>) -> bool,
     {
         let n = self.nodes[node];
         match n.ntype {
             NodeType::Empty => (),
 
             NodeType::Leaf(e) => {
-                let aabb = self.elements[e].position().unit_aabb().into();
+                let aabb = self.elements[e].position().unit_aabb();
                 if what(&aabb) {
                     elements.push(e);
                 };
             }
 
             NodeType::Branch(Branch { children, .. }) => {
-                let aabb: Aabb3d = n.aabb.into();
-
-                if what(&aabb) {
+                if what(&n.aabb) {
                     for child in children {
                         self.rintersect_with(child, what, elements);
                     }

--- a/src/bounding.rs
+++ b/src/bounding.rs
@@ -35,7 +35,7 @@ impl Unsigned for usize {}
 ///
 /// Inner typy shuld be any [`Unsigned`](num::Unsigned):
 /// `u8`, `u16`, `u32`, `u64`, `u128`, `usize`.
-#[derive(Default, Debug, PartialEq, Clone, Copy)]
+#[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub struct TUVec3<U: Unsigned> {
     pub x: U,
     pub y: U,

--- a/src/bounding.rs
+++ b/src/bounding.rs
@@ -12,7 +12,7 @@ use num::{cast, Integer, NumCast, Unsigned as NumUnsigned};
 
 use crate::TreeError;
 
-pub trait Unsigned = Integer
+pub trait Unsigned: Integer
     + NumUnsigned
     + NumCast
     + Shr<Self, Output = Self>
@@ -20,7 +20,15 @@ pub trait Unsigned = Integer
     + Copy
     + Display
     + Debug
-    + Default;
+    + Default
+{
+}
+impl Unsigned for u8 {}
+impl Unsigned for u16 {}
+impl Unsigned for u32 {}
+impl Unsigned for u64 {}
+impl Unsigned for u128 {}
+impl Unsigned for usize {}
 
 /// Tree Unsigned Vec3
 ///

--- a/src/bounding.rs
+++ b/src/bounding.rs
@@ -10,7 +10,7 @@ use std::{
 
 use num::{cast, Integer, NumCast, Unsigned as NumUnsigned};
 
-use crate::TreeError;
+use crate::{Position, TreeError};
 
 pub trait Unsigned:
     Integer
@@ -289,5 +289,75 @@ mod tests {
 
         // 7 is not the power of 2
         assert!(Aabb::new(TUVec3::splat(16u16), 7).is_err());
+    }
+}
+
+#[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+pub struct TUVec3u8(pub TUVec3<u8>);
+impl TUVec3u8 {
+    pub fn new(x: u8, y: u8, z: u8) -> Self {
+        TUVec3u8(TUVec3::new(x, y, z))
+    }
+}
+impl Position for TUVec3u8 {
+    type U = u8;
+    fn position(&self) -> TUVec3<u8> {
+        self.0
+    }
+}
+
+#[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+pub struct TUVec3u16(pub TUVec3<u16>);
+impl TUVec3u16 {
+    pub fn new(x: u16, y: u16, z: u16) -> Self {
+        TUVec3u16(TUVec3::new(x, y, z))
+    }
+}
+impl Position for TUVec3u16 {
+    type U = u16;
+    fn position(&self) -> TUVec3<u16> {
+        self.0
+    }
+}
+
+#[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+pub struct TUVec3u32(pub TUVec3<u32>);
+impl TUVec3u32 {
+    pub fn new(x: u32, y: u32, z: u32) -> Self {
+        TUVec3u32(TUVec3::new(x, y, z))
+    }
+}
+impl Position for TUVec3u32 {
+    type U = u32;
+    fn position(&self) -> TUVec3<u32> {
+        self.0
+    }
+}
+
+#[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+pub struct TUVec3u64(pub TUVec3<u64>);
+impl TUVec3u64 {
+    pub fn new(x: u64, y: u64, z: u64) -> Self {
+        TUVec3u64(TUVec3::new(x, y, z))
+    }
+}
+impl Position for TUVec3u64 {
+    type U = u64;
+    fn position(&self) -> TUVec3<u64> {
+        self.0
+    }
+}
+
+#[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+pub struct TUVec3u128(pub TUVec3<u128>);
+impl TUVec3u128 {
+    pub fn new(x: u128, y: u128, z: u128) -> Self {
+        TUVec3u128(TUVec3::new(x, y, z))
+    }
+}
+impl Position for TUVec3u128 {
+    type U = u128;
+    fn position(&self) -> TUVec3<u128> {
+        self.0
     }
 }

--- a/src/bounding.rs
+++ b/src/bounding.rs
@@ -12,7 +12,8 @@ use num::{cast, Integer, NumCast, Unsigned as NumUnsigned};
 
 use crate::TreeError;
 
-pub trait Unsigned: Integer
+pub trait Unsigned:
+    Integer
     + NumUnsigned
     + NumCast
     + Shr<Self, Output = Self>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,7 +497,7 @@ mod tests {
         assert!(tree.elements.len() > (RANGE as f32 * 0.98) as usize);
         assert!(tree.map.len() > (RANGE as f32 * 0.98) as usize);
 
-        for element in 0..tree.elements.len() {
+        for element in 0..tree.len() {
             let e = ElementId(element as u32);
             let pos = tree.elements[e].position;
             assert_eq!(tree.find(pos), Some(e));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //!
 //! Implement [`Position`] for the handled type, so that it can return it's spatial coordinates.
 //!
-//! ```ignore
+//! ```rust
 //! use bevy::math::{
 //!     bounding::{Aabb3d, BoundingSphere, RayCast3d},
 //!     Dir3, Vec3,
@@ -210,13 +210,22 @@ where
 
 /// Index [`tree.nodes`](pool::Pool) with it.
 ///
-/// ```ignore
+/// ```rust
 /// use oktree::prelude::*;
+/// use oktree::node::Node;
 ///
-/// let node: Node<u16> = tree.nodes[NodeId(0)];
+/// let mut tree = Octree::from_aabb_with_capacity(Aabb::new(TUVec3::splat(16), 16u16).unwrap(), 10);
+/// tree.insert(TUVec3u16::new(5, 5, 5)).unwrap();
+/// let node: Node<u16> = tree.get_node(ElementId(0)).unwrap();
 /// ```
 #[derive(Default, Clone, Copy, PartialEq, Debug)]
 pub struct NodeId(pub u32);
+
+impl From<NodeId> for ElementId {
+    fn from(value: NodeId) -> Self {
+        ElementId(value.0)
+    }
+}
 
 impl From<NodeId> for usize {
     fn from(value: NodeId) -> Self {
@@ -239,8 +248,12 @@ impl fmt::Display for NodeId {
 /// Index [`tree.elements`](pool::Pool) with it.
 /// Stored type element will be returned.
 ///
-/// ```ignore
-/// let element = tree.elements[ElementId(0)]
+/// ```rust
+/// use oktree::prelude::*;
+///
+/// let mut tree = Octree::from_aabb_with_capacity(Aabb::new(TUVec3::splat(16), 16u16).unwrap(), 10);
+/// tree.insert(TUVec3u16::new(5, 5, 5)).unwrap();
+/// let element: &TUVec3u16 = tree.get_element(ElementId(0)).unwrap();
 /// ```
 #[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct ElementId(pub u32);
@@ -471,7 +484,7 @@ mod tests {
         let c5 = DummyCell::new(TUVec3::new(6, 7, 1));
         assert_eq!(tree.insert(c5), Ok(ElementId(4)));
 
-        assert_eq!(tree.get_node(ElementId(0)), Some(NodeId(9)));
+        assert_eq!(tree.get_node_id(ElementId(0)), Some(NodeId(9)));
 
         assert_eq!(tree.nodes[0.into()].fullness(), Ok(2));
         assert_eq!(tree.nodes[1.into()].fullness(), Ok(2));
@@ -479,7 +492,7 @@ mod tests {
 
         assert_eq!(tree.remove(0.into()), Ok(()));
 
-        assert_eq!(tree.get_node(ElementId(0)), None);
+        assert_eq!(tree.get_node_id(ElementId(0)), None);
 
         assert_eq!(tree.nodes[0.into()].fullness(), Ok(2));
         assert_eq!(tree.nodes[1.into()].ntype, NodeType::Leaf(1.into()));
@@ -487,7 +500,7 @@ mod tests {
 
         assert_eq!(tree.remove(1.into()), Ok(()));
 
-        assert_eq!(tree.get_node(ElementId(1)), None);
+        assert_eq!(tree.get_node_id(ElementId(1)), None);
 
         assert_eq!(tree.nodes[0.into()].fullness(), Ok(1));
         assert_eq!(tree.nodes[1.into()].ntype, NodeType::Empty);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! To enable bevy integrations:
 //!
-//! ```
+//! ```toml
 //! [dependencies]
 //! oktree = { version = "0.2.0", features = ["bevy"] }
 //! ```
@@ -52,7 +52,7 @@
 //!
 //! Run benchmark:
 //!
-//! ```
+//! ```sh
 //! cargo bench --all-features
 //! ```
 //!
@@ -64,7 +64,7 @@
 //!
 //! Implement [`Position`] for the handled type, so that it can return it's spatial coordinates.
 //!
-//! ```rust
+//! ```ignore
 //! use bevy::math::{
 //!     bounding::{Aabb3d, BoundingSphere, RayCast3d},
 //!     Dir3, Vec3,
@@ -144,7 +144,7 @@
 //!
 //! Run bevy visual example:
 //!
-//! ```
+//! ```sh
 //! cargo run --release --example bevy_tree --all-features
 //! ```
 
@@ -174,8 +174,10 @@ pub trait Position {
 
 /// Index [`tree.nodes`](pool::Pool) with it.
 ///
-/// ```no_run
-/// let node: Node<u16> = tree.nodes[NodeId(0)]
+/// ```ignore
+/// use oktree::prelude::*;
+///
+/// let node: Node<u16> = tree.nodes[NodeId(0)];
 /// ```
 #[derive(Default, Clone, Copy, PartialEq, Debug)]
 pub struct NodeId(pub u32);
@@ -201,7 +203,7 @@ impl fmt::Display for NodeId {
 /// Index [`tree.elements`](pool::Pool) with it.
 /// Stored type element will be returned.
 ///
-/// ```no_run
+/// ```ignore
 /// let element = tree.elements[ElementId(0)]
 /// ```
 #[derive(Default, Clone, Copy, PartialEq, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,7 @@ impl fmt::Display for NodeId {
 /// ```ignore
 /// let element = tree.elements[ElementId(0)]
 /// ```
-#[derive(Default, Clone, Copy, PartialEq, Debug)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct ElementId(pub u32);
 
 impl From<ElementId> for usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,6 @@
 //! ```
 
 #![allow(dead_code)]
-#![feature(strict_overflow_ops)]
-#![feature(trait_alias)]
 
 #[cfg(feature = "bevy")]
 pub mod bevy_integration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,8 +160,11 @@ pub mod tree;
 
 use bounding::{TUVec3, Unsigned};
 use std::{
+    borrow::Cow,
     error::Error,
     fmt::{self},
+    ops::Deref,
+    sync::Arc,
 };
 
 // Implement on stored type to inform a tree
@@ -170,6 +173,39 @@ pub trait Position {
     type U: Unsigned;
 
     fn position(&self) -> TUVec3<Self::U>;
+}
+
+impl<T> Position for Cow<'_, T>
+where
+    T: Position + Clone,
+{
+    type U = T::U;
+
+    fn position(&self) -> TUVec3<Self::U> {
+        self.deref().position()
+    }
+}
+
+impl<T> Position for Arc<T>
+where
+    T: Position,
+{
+    type U = T::U;
+
+    fn position(&self) -> TUVec3<Self::U> {
+        self.deref().position()
+    }
+}
+
+impl<T> Position for Box<T>
+where
+    T: Position,
+{
+    type U = T::U;
+
+    fn position(&self) -> TUVec3<Self::U> {
+        self.deref().position()
+    }
 }
 
 /// Index [`tree.nodes`](pool::Pool) with it.

--- a/src/node.rs
+++ b/src/node.rs
@@ -98,12 +98,12 @@ impl Branch {
     }
 
     pub(crate) fn increment(&mut self) {
-        self.filled = self.filled.strict_add(1);
+        self.filled += 1;
         debug_assert!(self.filled <= 8);
     }
 
     pub(crate) fn decrement(&mut self) {
-        self.filled = self.filled.strict_sub(1);
+        self.filled -= 1;
     }
 
     /// Search which octant is suitable for the position.

--- a/src/node.rs
+++ b/src/node.rs
@@ -110,6 +110,7 @@ impl Branch {
     ///
     /// * `position`: Element's position
     /// * `center`: center of the current node's [`Aabb`]
+    #[inline(always)]
     pub fn find_child<U: Unsigned>(&self, position: TUVec3<U>, center: TUVec3<U>) -> NodeId {
         let x = if position.x < center.x { 0 } else { 1 };
         let y = if position.y < center.y { 0 } else { 1 };

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -163,6 +163,12 @@ impl<T> Pool<T> {
         }
     }
 
+    /// Clears all the items in the pool
+    pub fn clear(&mut self) {
+        self.vec.clear();
+        self.garbage.clear();
+    }
+
     /// Returns the number of actual elements.
     ///
     /// Elements marked as deleted are not counted.

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -90,7 +90,7 @@ impl Pool<NodeId> {
 
 /// Indexing a [`pool`](Pool) of [`nodes`](Node) with [`NodeId`]
 ///
-/// ```no_run
+/// ```ignore
 /// let node = &tree.nodes[NodeId(42)];
 /// // let node = &tree.nodes[ElementId(42)]; // Error
 /// ```
@@ -108,7 +108,7 @@ impl<U: Unsigned> Index<NodeId> for Pool<Node<U>> {
 
 /// Mutable Indexing a [`pool`](Pool) of [`nodes`](Node) with [`NodeId`]
 ///
-/// ```no_run
+/// ```ignore
 /// let mut node = &mut tree.nodes[NodeId(42)];
 /// // let mut node = &mut tree.nodes[ElementId(42)]; // Error
 /// ```
@@ -124,7 +124,7 @@ impl<U: Unsigned> IndexMut<NodeId> for Pool<Node<U>> {
 
 /// Indexing a [`pool`](Pool) of `T: Position` with [`ElementId`]
 ///
-/// ```no_run
+/// ```ignore
 /// let element = &tree.element[ElementId(42)];
 /// // let element = &tree.element[NodeId(42)]; // Error
 /// ```
@@ -142,7 +142,7 @@ impl<T: Position> Index<ElementId> for Pool<T> {
 
 /// Mutable Indexing a [`pool`](Pool) of `T: Position` with [`ElementId`]
 ///
-/// ```no_run
+/// ```ignore
 /// let mut element = &mut tree.element[ElementId(42)];
 /// // let mut element = &mut tree.element[NodeId(42)]; // Error
 /// ```
@@ -158,7 +158,7 @@ impl<T: Position> IndexMut<ElementId> for Pool<T> {
 
 /// Indexing a [`pool`](Pool) of [`node ids`](NodeId) with [`ElementId`]
 ///
-/// ```no_run
+/// ```ignore
 /// let node_id = &tree.map[ElementId(42)];
 /// // let node_id = &tree.map[NodeId(42)]; // Error
 /// ```
@@ -176,7 +176,7 @@ impl Index<ElementId> for Pool<NodeId> {
 
 /// Mutable Indexing a [`pool`](Pool) of [`node ids`](NodeId) with [`ElementId`]
 ///
-/// ```no_run
+/// ```ignore
 /// let mut node_id = &mut tree.map[ElementId(42)];
 /// // let mut node_id = &mut tree.map[NodeId(42)]; // Error
 /// ```

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -375,6 +375,10 @@ impl<T: Position> Pool<T> {
     pub fn is_garbaged(&self, element: ElementId) -> bool {
         self.garbage.contains(&(element.into()))
     }
+
+    pub fn has_garbage(&self) -> bool {
+        !self.garbage.is_empty()
+    }
 }
 
 impl Pool<NodeId> {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -284,6 +284,13 @@ impl<T> Pool<T> {
     pub fn iter(&self) -> PoolIterator<T> {
         PoolIterator::new(self)
     }
+
+    /// Returns a [`PoolIterator`], which iterates over an actual elements.
+    ///
+    /// Elements marked as deleted are skipped.
+    pub fn into_iter(self) -> impl IntoIterator<Item = T> {
+        self.vec.into_iter().filter(|i| !i.garbage).map(|i| i.item)
+    }
 }
 
 impl<U: Unsigned> Pool<Node<U>> {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -27,6 +27,18 @@ impl<T> From<T> for PoolItem<T> {
     }
 }
 
+impl<T> Clone for PoolItem<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        PoolItem {
+            item: self.item.clone(),
+            garbage: self.garbage,
+        }
+    }
+}
+
 /// [`Pool`] data structure.
 ///
 /// When element is removed no memory deallocation happens.
@@ -34,6 +46,35 @@ impl<T> From<T> for PoolItem<T> {
 pub struct Pool<T> {
     pub(crate) vec: Vec<PoolItem<T>>,
     pub(crate) garbage: Vec<usize>,
+}
+
+impl<T: Position> Clone for Pool<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Pool {
+            vec: self.vec.clone(),
+            garbage: self.garbage.clone(),
+        }
+    }
+}
+
+impl<U: Unsigned> Clone for Pool<Node<U>> {
+    fn clone(&self) -> Self {
+        Pool {
+            vec: self.vec.clone(),
+            garbage: self.garbage.clone(),
+        }
+    }
+}
+impl Clone for Pool<NodeId> {
+    fn clone(&self) -> Self {
+        Pool {
+            vec: self.vec.clone(),
+            garbage: self.garbage.clone(),
+        }
+    }
 }
 
 impl<U: Unsigned> Default for Pool<Node<U>> {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -295,7 +295,7 @@ impl<U: Unsigned> Pool<Node<U>> {
     #[inline(always)]
     pub(crate) fn remove(&mut self, node: NodeId) {
         let index: usize = node.into();
-        self.vec[node.0 as usize].garbage = true;
+        self.vec[index].garbage = true;
         self.garbage.push(index);
     }
 
@@ -407,7 +407,7 @@ impl<T: Position> Pool<T> {
     #[inline(always)]
     pub(crate) fn remove(&mut self, element: ElementId) {
         let index: usize = element.into();
-        self.vec[element.0 as usize].garbage = true;
+        self.vec[index].garbage = true;
         self.garbage.push(index);
     }
 
@@ -469,7 +469,7 @@ impl Pool<NodeId> {
     #[inline(always)]
     pub(crate) fn remove(&mut self, element: ElementId) {
         let index: usize = element.into();
-        self.vec[element.0 as usize].garbage = true;
+        self.vec[index].garbage = true;
         self.garbage.push(index);
     }
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -15,7 +15,6 @@ use crate::{
 /// [`PoolItem`] data structure that combines both the garbage flag
 /// and the actual item together for better cache locality.
 #[repr(align(8))]
-#[derive(Clone)]
 pub(crate) struct PoolItem<T> {
     pub(crate) item: T,
     pub(crate) garbage: bool,
@@ -28,15 +27,37 @@ impl<T> From<T> for PoolItem<T> {
         }
     }
 }
+impl<T> Clone for PoolItem<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        PoolItem {
+            item: self.item.clone(),
+            garbage: self.garbage,
+        }
+    }
+}
 
 /// [`Pool`] data structure.
 ///
 /// When element is removed no memory deallocation happens.
 /// Removed elements are only marked as deleted and their memory could be reused.  
-#[derive(Clone)]
 pub struct Pool<T> {
     pub(crate) vec: Vec<PoolItem<T>>,
     pub(crate) garbage: Vec<usize>,
+}
+
+impl<T> Clone for Pool<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            vec: self.vec.clone(),
+            garbage: self.garbage.clone(),
+        }
+    }
 }
 
 impl<U: Unsigned> Default for Pool<Node<U>> {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -31,6 +31,21 @@ impl<U: Unsigned> Default for Pool<Node<U>> {
         }
     }
 }
+impl<U: Unsigned> Pool<Node<U>> {
+    /// Clears all the items in the pool
+    pub fn clear(&mut self) {
+        self.vec.clear();
+        self.vec.push(Node::default());
+        self.garbage.clear();
+    }
+
+    /// Clears all the items in the pool and initiates it with an aabb.
+    pub fn clear_with_aabb(&mut self, aabb: Aabb<U>) {
+        self.vec.clear();
+        self.vec.push(Node::from_aabb(aabb, None));
+        self.garbage.clear();
+    }
+}
 
 impl<T: Position> Default for Pool<T> {
     fn default() -> Self {
@@ -40,6 +55,13 @@ impl<T: Position> Default for Pool<T> {
         }
     }
 }
+impl<T: Position> Pool<T> {
+    /// Clears all the items in the pool
+    pub fn clear(&mut self) {
+        self.vec.clear();
+        self.garbage.clear();
+    }
+}
 
 impl Default for Pool<NodeId> {
     fn default() -> Self {
@@ -47,6 +69,13 @@ impl Default for Pool<NodeId> {
             vec: Default::default(),
             garbage: Default::default(),
         }
+    }
+}
+impl Pool<NodeId> {
+    /// Clears all the items in the pool
+    pub fn clear(&mut self) {
+        self.vec.clear();
+        self.garbage.clear();
     }
 }
 
@@ -161,12 +190,6 @@ impl<T> Pool<T> {
             self.vec.push(t);
             self.vec.len() - 1
         }
-    }
-
-    /// Clears all the items in the pool
-    pub fn clear(&mut self) {
-        self.vec.clear();
-        self.garbage.clear();
     }
 
     /// Returns the number of actual elements.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,7 @@
 //! Crate's core types reimports.
 
 pub use crate::{
-    bounding::{Aabb, TUVec3, Unsigned},
+    bounding::{Aabb, TUVec3, TUVec3u128, TUVec3u16, TUVec3u32, TUVec3u64, TUVec3u8, Unsigned},
     node::NodeType,
     tree::Octree,
     ElementId, NodeId, Position, TreeError,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,7 +3,7 @@
 use crate::{
     bounding::{Aabb, TUVec3, Unsigned},
     node::{Branch, Node, NodeType},
-    pool::{Pool, PoolIterator},
+    pool::{Pool, PoolElementIterator, PoolIterator},
     ElementId, NodeId, Position, TreeError,
 };
 
@@ -360,6 +360,11 @@ where
     /// Returns an iterator over the nodes in the tree.
     pub fn iter_nodes(&self) -> PoolIterator<Node<U>> {
         self.nodes.iter()
+    }
+
+    /// Returns an iterator over the elements in the tree.
+    pub fn iter_elements<'a>(&'a self) -> PoolElementIterator<'a, T> {
+        self.elements.iter_elements()
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -298,23 +298,25 @@ where
         self.rfind(self.root, point)
     }
 
-    fn rfind(&self, node: NodeId, point: TUVec3<U>) -> Option<ElementId> {
-        let ntype = self.nodes[node].ntype;
-        match ntype {
-            NodeType::Empty => None,
+    fn rfind(&self, mut node: NodeId, point: TUVec3<U>) -> Option<ElementId> {
+        loop {
+            let ntype = self.nodes[node].ntype;
+            return match ntype {
+                NodeType::Empty => None,
 
-            NodeType::Leaf(e) => {
-                if self.elements[e].position() == point {
-                    Some(e)
-                } else {
-                    None
+                NodeType::Leaf(e) => {
+                    if self.elements[e].position() == point {
+                        Some(e)
+                    } else {
+                        None
+                    }
                 }
-            }
 
-            NodeType::Branch(ref branch) => {
-                let child = branch.find_child(point, self.nodes[node].aabb.center());
-                self.rfind(child, point)
-            }
+                NodeType::Branch(ref branch) => {
+                    node = branch.find_child(point, self.nodes[node].aabb.center());
+                    continue;
+                }
+            };
         }
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -271,6 +271,14 @@ where
         self.root = Default::default();
     }
 
+    /// Restores all the garbage elements back to real elements. Effectively
+    /// this is a rollback of all the remove operations that happened
+    pub fn restore_garbage(&mut self) {
+        self.elements.restore_garbage();
+        self.nodes.restore_garbage();
+        self.map.restore_garbage();
+    }
+
     /// Search for the element at the [`point`](TUVec3)
     ///
     /// Returns element's [`id`](ElementId) or [`None`] if elements if not found.
@@ -321,23 +329,12 @@ where
 
     /// Consumes a tree, converting it into a [`vector`](Vec).
     pub fn to_vec(self) -> Vec<T> {
-        if self.elements.has_garbage() {
-            let garbage = self.elements.garbage;
-            self.elements
-                .vec
-                .into_iter()
-                .enumerate()
-                .filter_map(|(i, element)| {
-                    if garbage.contains(&i) {
-                        None
-                    } else {
-                        Some(element)
-                    }
-                })
-                .collect()
-        } else {
-            self.elements.vec
-        }
+        self.elements
+            .vec
+            .into_iter()
+            .filter(|e| !e.garbage)
+            .map(|e| e.item)
+            .collect()
     }
 
     /// Returns the number of actual elements in the tree
@@ -351,12 +348,8 @@ where
     }
 
     /// Returns an iterator over the elements in the tree.
-    pub fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &T> + 'a> {
-        if self.elements.has_garbage() {
-            Box::new(self.elements.iter())
-        } else {
-            Box::new(self.elements.vec.iter())
-        }
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.elements.iter()
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -205,7 +205,7 @@ where
     ///
     /// let c1_id = tree.upsert(c1).unwrap();
     /// assert_eq!(c1_id, ElementId(0))
-    /// 
+    ///
     /// let c1_id = tree.upsert(c1).unwrap();
     /// assert_eq!(c1_id, ElementId(1))
     /// ```
@@ -251,7 +251,7 @@ where
     }
 
     /// Clear all the elements in the octree and reset it to the initial state.
-    /// 
+    ///
     /// The capacity of the octree is preserved and thus the octree can be immediately
     /// reused for new elements without causing any memory reallocations.
     pub fn clear(&mut self) {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -356,6 +356,11 @@ where
     pub fn into_iter(self) -> impl IntoIterator<Item = T> {
         self.elements.into_iter()
     }
+
+    /// Returns an iterator over the nodes in the tree.
+    pub fn iter_nodes(&self) -> PoolIterator<Node<U>> {
+        self.nodes.iter()
+    }
 }
 
 impl<U, T> Clone for Octree<U, T>

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -239,7 +239,7 @@ where
     /// let c1 = TUVec3u8::new(1u8, 1, 1);
     /// let c1_id = tree.insert(c1).unwrap();
     ///
-    /// assert_eq!(tree.remove(c1_id).is_ok(), true);
+    /// assert!(tree.remove(c1_id).is_ok());
     /// ```
     pub fn remove(&mut self, element: ElementId) -> Result<(), TreeError> {
         let node = self.map[element];

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -351,6 +351,11 @@ where
     pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.elements.iter()
     }
+
+    /// Returns an iterator over the elements in the tree.
+    pub fn into_iter(self) -> impl IntoIterator<Item = T> {
+        self.elements.into_iter()
+    }
 }
 
 impl<U, T> Clone for Octree<U, T>

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -22,17 +22,17 @@ where
     T: Position<U = U>,
 {
     /// [`Pool`] of stored elements. Access it by [`ElementId`]
-    pub elements: Pool<T>,
+    pub(crate) elements: Pool<T>,
 
     /// [`Pool`] of tree [`Nodes`](crate::node::Node). Access it by [`NodeId`]
-    pub nodes: Pool<Node<U>>,
+    pub(crate) nodes: Pool<Node<U>>,
 
     /// Every element caches its' [`NodeId`].
     /// Drastically speedup the elements removal.
     /// Access it by [`ElementId`]
-    pub map: Pool<NodeId>,
+    pub(crate) map: Pool<NodeId>,
 
-    pub root: NodeId,
+    pub(crate) root: NodeId,
 }
 
 impl<U, T> Octree<U, T>

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,7 +3,7 @@
 use crate::{
     bounding::{Aabb, TUVec3, Unsigned},
     node::{Branch, Node, NodeType},
-    pool::{Pool, PoolElementIterator, PoolIterator},
+    pool::{Pool, PoolElementIterator, PoolIntoIterator, PoolIterator},
     ElementId, NodeId, Position, TreeError,
 };
 
@@ -348,13 +348,8 @@ where
     }
 
     /// Returns an iterator over the elements in the tree.
-    pub fn iter<'a>(&'a self) -> PoolIterator<'a, T> {
+    pub fn iter(&self) -> PoolIterator<'_, T> {
         self.elements.iter()
-    }
-
-    /// Returns an iterator over the elements in the tree.
-    pub fn into_iter(self) -> impl IntoIterator<Item = T> {
-        self.elements.into_iter()
     }
 
     /// Returns an iterator over the nodes in the tree.
@@ -363,8 +358,17 @@ where
     }
 
     /// Returns an iterator over the elements in the tree.
-    pub fn iter_elements<'a>(&'a self) -> PoolElementIterator<'a, T> {
+    pub fn iter_elements(&self) -> PoolElementIterator<'_, T> {
         self.elements.iter_elements()
+    }
+}
+
+impl<U: Unsigned, T: Position<U = U>> std::iter::IntoIterator for Octree<U, T> {
+    type Item = T;
+    type IntoIter = PoolIntoIterator<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.into_iter()
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -326,6 +326,16 @@ where
             .collect()
     }
 
+    /// Returns the number of actual elements in the tree
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Is the tree empty
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
     /// Returns an iterator over the elements in the tree.
     pub fn iter(&self) -> PoolIterator<T> {
         self.elements.iter()

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -21,6 +21,9 @@ where
     U: Unsigned,
     T: Position<U = U>,
 {
+    /// aabb used for clearing the octree
+    aabb: Option<Aabb<U>>,
+
     /// [`Pool`] of stored elements. Access it by [`ElementId`]
     pub(crate) elements: Pool<T>,
 
@@ -46,6 +49,7 @@ where
     /// The root node will adopt aabb's dimensions.
     pub fn from_aabb(aabb: Aabb<U>) -> Self {
         Octree {
+            aabb: Some(aabb),
             elements: Default::default(),
             nodes: Pool::from_aabb(aabb),
             map: Default::default(),
@@ -58,6 +62,7 @@ where
     /// Helps to reduce the amount of the memory reallocations.
     pub fn with_capacity(capacity: usize) -> Self {
         Octree {
+            aabb: None,
             elements: Pool::<T>::with_capacity(capacity),
             nodes: Pool::<Node<U>>::with_capacity(capacity),
             map: Pool::<NodeId>::with_capacity(capacity),
@@ -72,6 +77,7 @@ where
     /// The root node will adopt aabb's dimensions.
     pub fn from_aabb_with_capacity(aabb: Aabb<U>, capacity: usize) -> Self {
         Octree {
+            aabb: Some(aabb),
             elements: Pool::<T>::with_capacity(capacity),
             nodes: Pool::<Node<U>>::from_aabb_with_capacity(aabb, capacity),
             map: Pool::<NodeId>::with_capacity(capacity),
@@ -257,7 +263,11 @@ where
     pub fn clear(&mut self) {
         self.elements.clear();
         self.map.clear();
-        self.nodes.clear();
+        if let Some(aabb) = self.aabb {
+            self.nodes.clear_with_aabb(aabb);
+        } else {
+            self.nodes.clear();
+        }
         self.root = Default::default();
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -353,6 +353,22 @@ where
     }
 }
 
+impl<U, T> Clone for Octree<U, T>
+where
+    U: Unsigned,
+    T: Position<U = U> + Clone,
+{
+    fn clone(&self) -> Self {
+        Octree {
+            aabb: self.aabb,
+            elements: self.elements.clone(),
+            nodes: self.nodes.clone(),
+            map: self.map.clone(),
+            root: self.root,
+        }
+    }
+}
+
 #[derive(Debug)]
 struct Insertion<U: Unsigned> {
     element: ElementId,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,7 +3,7 @@
 use crate::{
     bounding::{Aabb, TUVec3, Unsigned},
     node::{Branch, Node, NodeType},
-    pool::Pool,
+    pool::{Pool, PoolIterator},
     ElementId, NodeId, Position, TreeError,
 };
 
@@ -348,7 +348,7 @@ where
     }
 
     /// Returns an iterator over the elements in the tree.
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
+    pub fn iter<'a>(&'a self) -> PoolIterator<'a, T> {
         self.elements.iter()
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -90,7 +90,7 @@ where
     /// Recursively subdivide the space, creating new [`nodes`](crate::node::Node)
     /// Returns inserted element's [`id`](ElementId)
     ///
-    /// ```no_run
+    /// ```ignore
     /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
     /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
     /// let c1_id = tree.insert(c1).unwrap();
@@ -205,7 +205,7 @@ where
     /// Recursively subdivide the space, creating new [`nodes`](crate::node::Node)
     /// Returns inserted element's [`id`](ElementId)
     ///
-    /// ```no_run
+    /// ```ignore
     /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
     /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
     ///
@@ -228,7 +228,7 @@ where
     /// No memory deallocaton happening.
     /// Element is only marked as removed and could be reused.
     ///
-    /// ```no_run
+    /// ```ignore
     /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
     /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
     /// let c1_id = tree.insert(c1).unwrap();
@@ -275,7 +275,7 @@ where
     ///
     /// Returns element's [`id`](ElementId) or [`None`] if elements if not found.
     ///
-    /// ```no_run
+    /// ```ignore
     /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
     /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
     /// tree.insert(c1).unwrap();

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,7 +3,7 @@
 use crate::{
     bounding::{Aabb, TUVec3, Unsigned},
     node::{Branch, Node, NodeType},
-    pool::Pool,
+    pool::{Pool, PoolIterator},
     ElementId, NodeId, Position, TreeError,
 };
 
@@ -324,6 +324,11 @@ where
                 }
             })
             .collect()
+    }
+
+    /// Returns an iterator over the elements in the tree.
+    pub fn iter(&self) -> PoolIterator<T> {
+        self.elements.iter()
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -90,9 +90,11 @@ where
     /// Recursively subdivide the space, creating new [`nodes`](crate::node::Node)
     /// Returns inserted element's [`id`](ElementId)
     ///
-    /// ```ignore
-    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
-    /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
+    /// ```rust
+    /// use oktree::prelude::*;
+    ///
+    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16).unwrap());
+    /// let c1 = TUVec3u8::new(1u8, 1, 1);
     /// let c1_id = tree.insert(c1).unwrap();
     ///
     /// assert_eq!(c1_id, ElementId(0))
@@ -205,15 +207,17 @@ where
     /// Recursively subdivide the space, creating new [`nodes`](crate::node::Node)
     /// Returns inserted element's [`id`](ElementId)
     ///
-    /// ```ignore
-    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
-    /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
+    /// ```rust
+    /// use oktree::prelude::*;
+    ///
+    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16).unwrap());
+    /// let c1 = TUVec3u8::new(1u8, 1, 1);
     ///
     /// let c1_id = tree.upsert(c1).unwrap();
-    /// assert_eq!(c1_id, ElementId(0))
+    /// assert_eq!(c1_id, ElementId(0));
     ///
     /// let c1_id = tree.upsert(c1).unwrap();
-    /// assert_eq!(c1_id, ElementId(1))
+    /// assert_eq!(c1_id, ElementId(0));
     /// ```
     pub fn upsert(&mut self, elem: T) -> Result<ElementId, TreeError> {
         if let Some(existing) = self.find(elem.position()) {
@@ -228,12 +232,14 @@ where
     /// No memory deallocaton happening.
     /// Element is only marked as removed and could be reused.
     ///
-    /// ```ignore
-    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
-    /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
+    /// ```rust
+    /// use oktree::prelude::*;
+    ///
+    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16).unwrap());
+    /// let c1 = TUVec3u8::new(1u8, 1, 1);
     /// let c1_id = tree.insert(c1).unwrap();
     ///
-    /// assert_eq!(tree.remove(c1_id).is_ok())
+    /// assert_eq!(tree.remove(c1_id).is_ok(), true);
     /// ```
     pub fn remove(&mut self, element: ElementId) -> Result<(), TreeError> {
         let node = self.map[element];
@@ -283,12 +289,14 @@ where
     ///
     /// Returns element's [`id`](ElementId) or [`None`] if elements if not found.
     ///
-    /// ```ignore
-    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
-    /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
+    /// ```rust
+    /// use oktree::prelude::*;
+    ///
+    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16).unwrap());
+    /// let c1 = TUVec3u8::new(1u8, 1, 1);
     /// tree.insert(c1).unwrap();
     ///
-    /// let c2 = DummyCell::new(TUVec3::new(4, 5, 6));
+    /// let c2 = TUVec3u8::new(4, 5, 6);
     /// let eid = tree.insert(c2).unwrap();
     ///
     /// assert_eq!(tree.find(TUVec3::new(4, 5, 6)), Some(eid));
@@ -321,11 +329,29 @@ where
     }
 
     /// Returns the node's [`id`](NodeId) containing the element if element exists and not garbaged.
-    pub fn get_node(&self, element: ElementId) -> Option<NodeId> {
+    pub fn get_node_id(&self, element: ElementId) -> Option<NodeId> {
         if self.map.is_garbaged(element) {
             None
         } else {
-            Some(self.map[element])
+            Some(self.map[element.into()])
+        }
+    }
+
+    /// Returns the node's [`id`](NodeId) containing the element if element exists and not garbaged.
+    pub fn get_node(&self, element: ElementId) -> Option<Node<U>> {
+        if self.map.is_garbaged(element) {
+            None
+        } else {
+            Some(self.nodes[self.map[element.into()]])
+        }
+    }
+
+    /// Returns the element if element exists and not garbaged.
+    pub fn get_element(&self, element: ElementId) -> Option<&T> {
+        if self.elements.is_garbaged(element) {
+            None
+        } else {
+            Some(&self.elements[element])
         }
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -194,6 +194,28 @@ where
         Ok(())
     }
 
+    /// Upserts an element into a tree.
+    ///
+    /// Recursively subdivide the space, creating new [`nodes`](crate::node::Node)
+    /// Returns inserted element's [`id`](ElementId)
+    ///
+    /// ```no_run
+    /// let mut tree = Octree::from_aabb(Aabb::new(TUVec3::splat(16), 16));
+    /// let c1 = DummyCell::new(TUVec3::new(1u8, 1, 1));
+    ///
+    /// let c1_id = tree.upsert(c1).unwrap();
+    /// assert_eq!(c1_id, ElementId(0))
+    /// 
+    /// let c1_id = tree.upsert(c1).unwrap();
+    /// assert_eq!(c1_id, ElementId(1))
+    /// ```
+    pub fn upsert(&mut self, elem: T) -> Result<ElementId, TreeError> {
+        if let Some(existing) = self.find(elem.position()) {
+            self.remove(existing)?;
+        }
+        self.insert(elem)
+    }
+
     /// Remove an element from the tree.
     ///
     /// Recursively collapse an empty [`nodes`](crate::node::Node).
@@ -226,6 +248,17 @@ where
                 n.ntype
             ))),
         }
+    }
+
+    /// Clear all the elements in the octree and reset it to the initial state.
+    /// 
+    /// The capacity of the octree is preserved and thus the octree can be immediately
+    /// reused for new elements without causing any memory reallocations.
+    pub fn clear(&mut self) {
+        self.elements.clear();
+        self.map.clear();
+        self.nodes.clear();
+        self.root = Default::default();
     }
 
     /// Search for the element at the [`point`](TUVec3)


### PR DESCRIPTION
- Added a `clear` method that is useful for reusing the octree from a clear slate
- Added a `upsert` method that can handle the situation when an element already exists at the target position
- Hidden away the internal structures from external consumers of the crate
- Exposed an `iter` method that gives access to the elements without the need to access internal structures
- Added `len` method that will return the number of elements in the tree without the need to access internal structures
- Added `is_empty` method that will return true if the tree is empty without the need to access internal structures
- Added an automatic formatting settings when using visual code (on save it will reformat)
- Removed the dependency on unstable rust, will now compile on stable rust
- Optimizations for when the octree has no garbage
- Implemented a faster garbage engine that scales better when lots of garbage exists
- Tweaked the garbage system and the benchmarks and improved the performance
- Iterators now support reverse direction
- Octree is now clonable
- Implemented `into_iter`
- Added more Position trait implementations for Arc, Box and Cow